### PR TITLE
Only apply NormalizeWhitespace where required. Fixes #7.

### DIFF
--- a/MoveClassToFile/MoveClassToFile/MoveClassToFileCodeRefactoringProvider.cs
+++ b/MoveClassToFile/MoveClassToFile/MoveClassToFileCodeRefactoringProvider.cs
@@ -64,10 +64,26 @@ namespace MoveClassToFile
                 .WithMembers(
                             SyntaxFactory.SingletonList<MemberDeclarationSyntax>(
                                 SyntaxFactory.NamespaceDeclaration(
-                                    SyntaxFactory.IdentifierName(typeSymbol.ContainingNamespace.ToString()))
-                .WithMembers(SyntaxFactory.SingletonList<MemberDeclarationSyntax>(typeDecl))))
+                                    SyntaxFactory.IdentifierName(typeSymbol.ContainingNamespace.ToString()))))
                 .WithoutLeadingTrivia()
                 .NormalizeWhitespace();
+
+            newFileTree = newFileTree
+                .WithMembers(
+                    SyntaxFactory.List<MemberDeclarationSyntax>(
+                        newFileTree
+                            .Members
+                            .Select(
+                                m =>
+                                {
+                                    if (m is NamespaceDeclarationSyntax)
+                                    {
+                                        return ((NamespaceDeclarationSyntax)m).WithMembers(
+                                            SyntaxFactory.SingletonList<MemberDeclarationSyntax>(typeDecl));
+                                    }
+                                    else
+                                        return m;
+                                })));
 
             //move to new File
             //TODO: handle name conflicts
@@ -96,9 +112,9 @@ namespace MoveClassToFile
 
             root = root.RemoveNodes(oldUsings, SyntaxRemoveOptions.KeepNoTrivia);
             var newUsings = SyntaxFactory.List(oldUsings.Except(unusedUsings));
+            
             root = ((CompilationUnitSyntax)root)
                 .WithUsings(newUsings)
-                .NormalizeWhitespace()
                 .WithLeadingTrivia(leadingTrivia);
 
             return root;


### PR DESCRIPTION
This fix retains the original formatting of code extracted from the original document, and also does not adjust the format of the remaining code left behind in the original document. A possible downside of this fix is that the extracted code will not be reindented (it might have been nested inside multiple `namespace` declarations in the original document). However, `NormalizeWhitespace` does not take account of code formatting and indentation preferences within Visual Studio, so any reformatting performed this way would have undesirable consequences for users using non-default code formatting settings. Further, automatic code reformatting is not always desirable, for example where it's clearer to arrange the initialization of complex elements in a collection in neat columns. As such, I'd argue that code reformatting should not be implicitly conflated with the operation of moving a class to another file.